### PR TITLE
read entities one line at a time

### DIFF
--- a/blink/main_dense.py
+++ b/blink/main_dense.py
@@ -101,8 +101,7 @@ def _load_candidates(entity_catalogue, entity_encoding):
     wikipedia_id2local_id = {}
     local_idx = 0
     with open(entity_catalogue, "r") as fin:
-        lines = fin.readlines()
-        for line in lines:
+        for line in fin:
             entity = json.loads(line)
 
             if "idx" in entity:


### PR DESCRIPTION
This reduces the required amount of RAM to ~35 GB for the `--fast` (bi-encoder only) version. I can't report memory requirements for the full version (bi-encoder & cross-encoder) yet, but it will see a reduction in the required amount of RAM as well. 