### PR TITLE
Add FAISS indexer in BLINK

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,39 @@ chmod +x download_models.sh
 ./download_models.sh
 ```
 
+We additionally provide a [FAISS](https://github.com/facebookresearch/faiss) indexer in BLINK, which enables efficient exact/approximate retrieval for biencoder model.
+
+- [flat index](s3://dl.fbaipublicfiles.com/BLINK/faiss_flat_index.pkl)
+- [hnsw (approximate search) index](s3://dl.fbaipublicfiles.com/BLINK/faiss_hnsw_index.pkl)
+
+
+To build and save FAISS (exact search) index yourself, run
+`python blink/build_faiss_index.py --output_path models/faiss_flat_index.pkl`
+
+
 ### 3. Use BLINK interactively
 A quick way to explore the BLINK linking capabilities is through the `main_dense` interactive script. BLINK uses [Flair](https://github.com/flairNLP/flair) for Named Entity Recognition (NER) to obtain entity mentions from input text, then run entity linking. 
 
 ```console
 python blink/main_dense.py -i
 ```
+
 Fast mode: in the fast mode the model only uses the bi-encoder, which is much faster (accuracy drops slightly, see details in "Benchmarking BLINK" section). 
 
 ```console
 python blink/main_dense.py -i --fast
 ```
+
+To run BLINK with saved FAISS index, run:
+```console
+python blink/main_dense.py --faiss_index flat --index_path models/faiss_flat_index.pkl
+```
+or 
+```console
+python blink/main_dense.py --faiss_index hnsw --index_path models/faiss_hnsw_index.pkl
+```
+
+
 Example: 
 ```console
 Bert and Ernie are two Muppets who appear together in numerous skits on the popular children's television show of the United States, Sesame Street.

--- a/blink/build_faiss_index.py
+++ b/blink/build_faiss_index.py
@@ -1,0 +1,74 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+import argparse
+import logging
+import numpy
+import os
+import time
+import torch
+
+from blink.indexer.faiss_indexer import DenseFlatIndexer, DenseHNSWFlatIndexer
+import blink.candidate_ranking.utils as utils
+
+logger = utils.get_logger()
+
+def main(params): 
+    output_path = params["output_path"]
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+    logger = utils.get_logger(output_path)
+
+    logger.info("Loading candidate encoding from path: %s" % params["candidate_encoding"])
+    candidate_encoding = torch.load(params["candidate_encoding"])
+    vector_size = candidate_encoding.size(1)
+    index_buffer = params["index_buffer"]
+    if params["hnsw"]:
+        logger.info("Using HNSW index in FAISS")
+        index = DenseHNSWFlatIndexer(vector_size, index_buffer)
+    else:
+        logger.info("Using Flat index in FAISS")
+        index = DenseFlatIndexer(vector_size, index_buffer)
+
+    logger.info("Building index.")
+    index.index_data(candidate_encoding.numpy())
+    logger.info("Done indexing data.")
+
+    if params.get("save_index", None):
+        index.serialize(output_path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output_path",
+        required=True,
+        type=str,
+        help="output file path",
+    )
+    parser.add_argument(
+        "--candidate_encoding",
+        default="/private/home/ledell/BLINK-Internal/models/all_entities_large.t7",
+        type=str,
+        help="file path for candidte encoding.",
+    )
+    parser.add_argument(
+        "--hnsw", action='store_true', 
+        help='If enabled, use inference time efficient HNSW index',
+    )
+    parser.add_argument(
+        "--save_index", action='store_true', 
+        help='If enabled, save index',
+    )
+    parser.add_argument(
+        '--index_buffer', type=int, default=50000,
+        help="Temporal memory data buffer size (in samples) for indexer",
+    )
+
+    params = parser.parse_args()
+    params = params.__dict__
+
+    main(params)

--- a/blink/index/faiss_indexer.py
+++ b/blink/index/faiss_indexer.py
@@ -1,0 +1,133 @@
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+"""
+FAISS-based index components. Original from 
+https://github.com/facebookresearch/DPR/blob/master/dpr/indexer/faiss_indexers.py
+"""
+
+import os
+import logging
+import pickle
+
+import faiss
+import numpy as np
+
+logger = logging.getLogger()
+
+class DenseIndexer(object):
+
+    def __init__(self, buffer_size: int = 50000):
+        self.buffer_size = buffer_size
+        self.index_id_to_db_id = []
+        self.index = None
+
+    def index_data(self, data: np.array):
+        raise NotImplementedError
+
+    def search_knn(self, query_vectors: np.array, top_docs: int):
+        raise NotImplementedError
+
+    def serialize(self, file: str):
+        logger.info('Serializing index to %s', file)
+        index_file = os.path.join(file, "index.pkl")
+        faiss.write_index(self.index, index_file)
+
+    def deserialize_from(self, file: str):
+        logger.info('Loading index from %s', file)
+        index_file = os.path.join(file, "index.pkl")
+        self.index = faiss.read_index(index_file)
+        logger.info('Loaded index of type %s and size %d', type(self.index), self.index.ntotal)
+
+
+# DenseFlatIndexer does exact search
+class DenseFlatIndexer(DenseIndexer):
+
+    def __init__(self, vector_sz: int = 1, buffer_size: int = 50000):
+        super(DenseFlatIndexer, self).__init__(buffer_size=buffer_size)
+        self.index = faiss.IndexFlatIP(vector_sz)
+
+    def index_data(self, data: np.array):
+        n = len(data)
+        # indexing in batches is beneficial for many faiss index types
+        logger.info("Indexing data, this may take a while.")
+        cnt = 0
+        for i in range(0, n, self.buffer_size):
+            vectors = [np.reshape(t, (1, -1)) for t in data[i:i + self.buffer_size]]
+            vectors = np.concatenate(vectors, axis=0)
+            self.index.add(vectors)
+            cnt += self.buffer_size
+
+        logger.info('Total data indexed %d', n)
+
+    def search_knn(self, query_vectors, top_k):
+        scores, indexes = self.index.search(query_vectors, top_k)
+        return scores, indexes
+
+
+# DenseHNSWFlatIndexer does approximate search
+class DenseHNSWFlatIndexer(DenseIndexer):
+    """
+     Efficient index for retrieval. Note: default settings are for hugh accuracy but also high RAM usage
+    """
+
+    def __init__(self, vector_sz: int, buffer_size: int = 50000, store_n: int = 128
+                 , ef_search: int = 256, ef_construction: int = 200):
+        super(DenseHNSWFlatIndexer, self).__init__(buffer_size=buffer_size)
+
+        # IndexHNSWFlat supports L2 similarity only
+        # so we have to apply DOT -> L2 similairy space conversion with the help of an extra dimension
+        index = faiss.IndexHNSWFlat(vector_sz + 1, store_n)
+        index.hnsw.efSearch = ef_search
+        index.hnsw.efConstruction = ef_construction
+        self.index = index
+        self.phi = 0
+
+    def index_data(self, data: np.array):
+        n = len(data)
+
+        # max norm is required before putting all vectors in the index to convert inner product similarity to L2
+        if self.phi > 0:
+            raise RuntimeError('DPR HNSWF index needs to index all data at once,'
+                               'results will be unpredictable otherwise.')
+        phi = 0
+        for i, item in enumerate(data):
+            doc_vector = item
+            norms = (doc_vector ** 2).sum()
+            phi = max(phi, norms)
+        logger.info('HNSWF DotProduct -> L2 space phi={}'.format(phi))
+        self.phi = 0
+
+        # indexing in batches is beneficial for many faiss index types
+        logger.info("Indexing data, this may take a while.")
+        cnt = 0
+        for i in range(0, n, self.buffer_size):
+            vectors = [np.reshape(t, (1, -1)) for t in data[i:i + self.buffer_size]]
+
+            norms = [(doc_vector ** 2).sum() for doc_vector in vectors]
+            aux_dims = [np.sqrt(phi - norm) for norm in norms]
+            hnsw_vectors = [np.hstack((doc_vector, aux_dims[i].reshape(-1, 1))) for i, doc_vector in
+                            enumerate(vectors)]
+            hnsw_vectors = np.concatenate(hnsw_vectors, axis=0)
+
+            self.index.add(hnsw_vectors)
+            cnt += self.buffer_size
+            logger.info("Indexed data %d" % cnt)
+
+        logger.info('Total data indexed %d' % n)
+
+    def search_knn(self, query_vectors, top_k):
+        aux_dim = np.zeros(len(query_vectors), dtype='float32')
+        query_nhsw_vectors = np.hstack((query_vectors, aux_dim.reshape(-1, 1)))
+        logger.info('query_hnsw_vectors %s', query_nhsw_vectors.shape)
+        scores, indexes = self.index.search(query_nhsw_vectors, top_k)
+        return scores, indexes
+
+    def deserialize_from(self, file: str):
+        super(DenseHNSWFlatIndexer, self).deserialize_from(file)
+        # to trigger warning on subsequent indexing
+        self.phi = 1

--- a/blink/index/faiss_indexer.py
+++ b/blink/index/faiss_indexer.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #
@@ -19,8 +18,8 @@ import numpy as np
 
 logger = logging.getLogger()
 
-class DenseIndexer(object):
 
+class DenseIndexer(object):
     def __init__(self, buffer_size: int = 50000):
         self.buffer_size = buffer_size
         self.index_id_to_db_id = []
@@ -32,21 +31,20 @@ class DenseIndexer(object):
     def search_knn(self, query_vectors: np.array, top_docs: int):
         raise NotImplementedError
 
-    def serialize(self, file: str):
-        logger.info('Serializing index to %s', file)
-        index_file = os.path.join(file, "index.pkl")
+    def serialize(self, index_file: str):
+        logger.info("Serializing index to %s", index_file)
         faiss.write_index(self.index, index_file)
 
-    def deserialize_from(self, file: str):
-        logger.info('Loading index from %s', file)
-        index_file = os.path.join(file, "index.pkl")
+    def deserialize_from(self, index_file: str):
+        logger.info("Loading index from %s", index_file)
         self.index = faiss.read_index(index_file)
-        logger.info('Loaded index of type %s and size %d', type(self.index), self.index.ntotal)
+        logger.info(
+            "Loaded index of type %s and size %d", type(self.index), self.index.ntotal
+        )
 
 
 # DenseFlatIndexer does exact search
 class DenseFlatIndexer(DenseIndexer):
-
     def __init__(self, vector_sz: int = 1, buffer_size: int = 50000):
         super(DenseFlatIndexer, self).__init__(buffer_size=buffer_size)
         self.index = faiss.IndexFlatIP(vector_sz)
@@ -57,12 +55,12 @@ class DenseFlatIndexer(DenseIndexer):
         logger.info("Indexing data, this may take a while.")
         cnt = 0
         for i in range(0, n, self.buffer_size):
-            vectors = [np.reshape(t, (1, -1)) for t in data[i:i + self.buffer_size]]
+            vectors = [np.reshape(t, (1, -1)) for t in data[i : i + self.buffer_size]]
             vectors = np.concatenate(vectors, axis=0)
             self.index.add(vectors)
             cnt += self.buffer_size
 
-        logger.info('Total data indexed %d', n)
+        logger.info("Total data indexed %d", n)
 
     def search_knn(self, query_vectors, top_k):
         scores, indexes = self.index.search(query_vectors, top_k)
@@ -75,8 +73,14 @@ class DenseHNSWFlatIndexer(DenseIndexer):
      Efficient index for retrieval. Note: default settings are for hugh accuracy but also high RAM usage
     """
 
-    def __init__(self, vector_sz: int, buffer_size: int = 50000, store_n: int = 128
-                 , ef_search: int = 256, ef_construction: int = 200):
+    def __init__(
+        self,
+        vector_sz: int,
+        buffer_size: int = 50000,
+        store_n: int = 128,
+        ef_search: int = 256,
+        ef_construction: int = 200,
+    ):
         super(DenseHNSWFlatIndexer, self).__init__(buffer_size=buffer_size)
 
         # IndexHNSWFlat supports L2 similarity only
@@ -92,38 +96,42 @@ class DenseHNSWFlatIndexer(DenseIndexer):
 
         # max norm is required before putting all vectors in the index to convert inner product similarity to L2
         if self.phi > 0:
-            raise RuntimeError('DPR HNSWF index needs to index all data at once,'
-                               'results will be unpredictable otherwise.')
+            raise RuntimeError(
+                "DPR HNSWF index needs to index all data at once,"
+                "results will be unpredictable otherwise."
+            )
         phi = 0
         for i, item in enumerate(data):
             doc_vector = item
             norms = (doc_vector ** 2).sum()
             phi = max(phi, norms)
-        logger.info('HNSWF DotProduct -> L2 space phi={}'.format(phi))
+        logger.info("HNSWF DotProduct -> L2 space phi={}".format(phi))
         self.phi = 0
 
         # indexing in batches is beneficial for many faiss index types
         logger.info("Indexing data, this may take a while.")
         cnt = 0
         for i in range(0, n, self.buffer_size):
-            vectors = [np.reshape(t, (1, -1)) for t in data[i:i + self.buffer_size]]
+            vectors = [np.reshape(t, (1, -1)) for t in data[i : i + self.buffer_size]]
 
             norms = [(doc_vector ** 2).sum() for doc_vector in vectors]
             aux_dims = [np.sqrt(phi - norm) for norm in norms]
-            hnsw_vectors = [np.hstack((doc_vector, aux_dims[i].reshape(-1, 1))) for i, doc_vector in
-                            enumerate(vectors)]
+            hnsw_vectors = [
+                np.hstack((doc_vector, aux_dims[i].reshape(-1, 1)))
+                for i, doc_vector in enumerate(vectors)
+            ]
             hnsw_vectors = np.concatenate(hnsw_vectors, axis=0)
 
             self.index.add(hnsw_vectors)
             cnt += self.buffer_size
             logger.info("Indexed data %d" % cnt)
 
-        logger.info('Total data indexed %d' % n)
+        logger.info("Total data indexed %d" % n)
 
     def search_knn(self, query_vectors, top_k):
-        aux_dim = np.zeros(len(query_vectors), dtype='float32')
+        aux_dim = np.zeros(len(query_vectors), dtype="float32")
         query_nhsw_vectors = np.hstack((query_vectors, aux_dim.reshape(-1, 1)))
-        logger.info('query_hnsw_vectors %s', query_nhsw_vectors.shape)
+        logger.info("query_hnsw_vectors %s", query_nhsw_vectors.shape)
         scores, indexes = self.index.search(query_nhsw_vectors, top_k)
         return scores, indexes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ flair==0.4.3
 pytorch-transformers==1.2.0
 colorama==0.4.3
 termcolor==1.1.0
+faiss-cpu>=1.6.1

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ setup(
         "pytorch-transformers>=1.2.0",
         "colorama>=0.4.3",
         "termcolor>=1.1.0",
+        "faiss-cpu>=1.6.1",
     ],
 )


### PR DESCRIPTION
This adds support to [FAISS](https://github.com/facebookresearch/faiss) indexer in BLINK, which enables efficient exact/approximate retrieval for biencoder model.
To build and save FAISS (exact search) index, run
`python blink/build_faiss_index.py --output_path models/faiss_flat_index.pkl`

Add flag `--hnsw` to build HNSW (approximate search) index.

To run BLINK with saved FAISS index, run
`python blink/main_dense.py --faiss_index flat --index_path models/faiss_flat_index.pkl`

