### PR TITLE
[Fix] Bug fix in PARAMETERS at run_benchmark.py and kwargs in _load_candidate() at main_dense.py

### DIFF
--- a/blink/main_dense.py
+++ b/blink/main_dense.py
@@ -312,7 +312,7 @@ def load_models(args, logger=None):
         wikipedia_id2local_id,
         faiss_indexer,
     ) = _load_candidates(
-        args.entity_catalogue, args.entity_encoding, args.faiss_index, args.index_path,
+        args.entity_catalogue, args.entity_encoding, faiss_index=args.faiss_index, index_path=args.index_path,
     )
 
     return (

--- a/blink/run_benchmark.py
+++ b/blink/run_benchmark.py
@@ -27,6 +27,8 @@ DATASETS = [
 ]
 
 PARAMETERS = {
+    "faiss_index": None,
+    "index_path": None,
     "test_entities": None,
     "test_mentions": None,
     "interactive": False,
@@ -38,6 +40,7 @@ PARAMETERS = {
     "crossencoder_config": "models/crossencoder_wiki_large.json",
     "output_path": "output",
     "fast": False,
+    "top_k": 100,
 }
 args = argparse.Namespace(**PARAMETERS)
 


### PR DESCRIPTION
Some commands for running the benchmark are given on the README:

```
./scripts/get_train_and_benchmark_data.sh
python scripts/create_BLINK_benchmark_data.py
python blink/run_benchmark.py
```

The command `python blink/run_benchmark.py` won't work on the current version of this repository unless the changes suggested in this pull request are made.