### PR TITLE
should separate filepath and directory path when making a directory

### DIFF
--- a/blink/build_faiss_index.py
+++ b/blink/build_faiss_index.py
@@ -19,7 +19,8 @@ logger = utils.get_logger()
 def main(params): 
     output_path = params["output_path"]
     if not os.path.exists(output_path):
-        os.makedirs(output_path)
+        d,f = os.path.split(output_path)
+        os.makedirs(d)
     logger = utils.get_logger(output_path)
 
     logger.info("Loading candidate encoding from path: %s" % params["candidate_encoding"])


### PR DESCRIPTION
Previous behavior for `build_faiss_index.py --output_path models/faiss_flat_index.pkl` was to create a directory `models/faiss_flat_index.pkl`. This would result in a crash after building the index because we need to write to a file not a directory. Suggested change is to use an `os` utility to separate out the directory and filename. 