### PR TITLE
separate directory path from filepath to make directories

### DIFF
--- a/blink/build_faiss_index.py
+++ b/blink/build_faiss_index.py
@@ -21,7 +21,7 @@ def main(params):
     output_dir, _ = os.path.split(output_path)
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-    logger = utils.get_logger(output_path)
+    logger = utils.get_logger(output_dir)
 
     logger.info("Loading candidate encoding from path: %s" % params["candidate_encoding"])
     candidate_encoding = torch.load(params["candidate_encoding"])

--- a/blink/build_faiss_index.py
+++ b/blink/build_faiss_index.py
@@ -18,8 +18,9 @@ logger = utils.get_logger()
 
 def main(params): 
     output_path = params["output_path"]
-    if not os.path.exists(output_path):
-        os.makedirs(output_path)
+    output_dir, _ = os.path.split(output_path)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
     logger = utils.get_logger(output_path)
 
     logger.info("Loading candidate encoding from path: %s" % params["candidate_encoding"])


### PR DESCRIPTION
Previous behavior was for `python blink/build_faiss_index.py --save_index --hnsw --output_path models/faiss_hnsw_index.pkl` to write out a directory then fail when saving the index because the index needs to be written as a file. This pull requests separates the directory, creates the directory, then maintains the output path so a file can be written.