### PR TITLE
Update train_ELQ.sh

### DIFF
--- a/scripts/train_ELQ.sh
+++ b/scripts/train_ELQ.sh
@@ -21,5 +21,5 @@ then
     epoch=-1
 fi
 
-bash elq_slurm_scripts/train_elq.sh $data all_avg $objective $train_batch_size $max_context_length true true large qa_linear 0 -1 $epoch $eval_batch_size $base_data $base_epoch
+bash elq_slurm_scripts/train_elq.sh $data all_avg $objective $train_batch_size $max_context_length false false large qa_linear 0 -1 $epoch $eval_batch_size $base_data $base_epoch
 


### PR DESCRIPTION
if load_save_cand_encs, adversarial two argument is true, at first training, candidate encoding(saved file-t7) should not be used.