### PR TITLE
Don't initialize id2url for non-interative blink runs

### DIFF
--- a/blink/main_dense.py
+++ b/blink/main_dense.py
@@ -363,10 +363,13 @@ def run(
         )
         raise ValueError(msg)
 
-    id2url = {
-        v: "https://en.wikipedia.org/wiki?curid=%s" % k
-        for k, v in wikipedia_id2local_id.items()
-    }
+    if args.interactive:
+        id2url = {
+            v: "https://en.wikipedia.org/wiki?curid=%s" % k
+            for k, v in wikipedia_id2local_id.items()
+        }
+    else:
+        id2url = {}
 
     stopping_condition = False
     while not stopping_condition:


### PR DESCRIPTION
This should make repeated calls to `run()` in the non-interactive mode more efficient.