### PR TITLE
fix "load_entity_dict_zeshel" function

### DIFF
--- a/blink/biencoder/zeshel_utils.py
+++ b/blink/biencoder/zeshel_utils.py
@@ -56,7 +56,7 @@ def load_entity_dict_zeshel(logger, params):
                 line = line.rstrip()
                 item = json.loads(line)
                 text = item["text"]
-                doc_list.append(text[:256])
+                doc_list.append(" ".join(text.split()[:128]))
 
                 if params["debug"]:
                     if len(doc_list) > 200:


### PR DESCRIPTION
I find a small bug in the "load_entity_dict_zeshel" function.  The original codes only consider a very small length of the entity's description, which harms the recall.
This may be related to issue #69.