### PR TITLE
Fixed script for downloading  Zero-shot Entity Linking (zeshel) dataset from Google Drive

### DIFF
--- a/examples/zeshel/get_zeshel_data.sh
+++ b/examples/zeshel/get_zeshel_data.sh
@@ -13,9 +13,8 @@ fi
 
 fileid="1ZcKZ1is0VEkY9kNfPxIG19qEIqHE5LIO"
 filename="zeshel.tar.bz2"
-curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}" > /dev/null
-curl -Lb ./cookie "https://drive.google.com/uc?export=download&confirm=`awk '/download/ {print $NF}' ./cookie`&id=${fileid}" -o ${filename}
-rm cookie
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o ${filename}
 
 tar -xf $filename -C $zeshel_data_folder
 rm ${filename}


### PR DESCRIPTION
The specifications for downloading large files from Google Drive have changed. 

Essentially, following instructions from [here](https://gist.github.com/tanaikech/f0f2d122e05bf5f971611258c22c110f).