### PR TITLE
Add gensim==3.8.3 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ transformers==3.1.0
 colorama==0.4.3
 termcolor==1.1.0
 faiss-cpu>=1.6.1
+gensim==3.8.3


### PR DESCRIPTION
By default it installs `gensim-4.0.1` which throws `AttributeError: 'KeyedVectors' object has no attribute 'key_to_index'` -- it has to do with flair's pre-reqs. Fix from [here](https://github.com/flairNLP/flair/issues/2196).